### PR TITLE
Optional Update/Insert upon id is submitted

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -927,6 +927,7 @@
             $query = array();
             $values = array_values($this->_dirty_fields);
 
+            $this->_is_new = is_null($this->id());
             if (!$this->_is_new) { // UPDATE
                 // If there are no dirty values, do nothing
                 if (count($values) == 0) {


### PR DESCRIPTION
If id is given, save will update instead of inserting a new record.

form submits $_POST[id]=1, $_POST[name]='John Doe'...
$user = ORM::for_table('user')->create($_POST);
$user->save(); Updates the user with id 1.

form submits $_POST[name]='Jane Doe'...
$user = ORM::for_table('user')->create($_POST);
$user->save(); No id was submited. Inserting a new record.

Advantages:
1 form to add or edit content (providing id or not)
1 code to insert or update instead of separated insert and update
