### PR TITLE
Add support for raw order by clauses

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -208,9 +208,9 @@ Two methods are provided to add `ORDER BY` clauses to your query. These are `ord
 
     $people = ORM::for_table('person')->order_by_asc('gender')->order_by_desc('name')->find_many();
 
-If you want to order by something other than a column name, then use the `order_raw` method to add a raw `ORDER BY` clause.
+If you want to order by something other than a column name, then use the `order_by_expr` method to add an unquoted SQL expression as an `ORDER BY` clause.
 
-    $people = ORM::for_table('person')->order_raw('SOUNDEX(`name`)')->find_many();
+    $people = ORM::for_table('person')->order_by_expr('SOUNDEX(`name`)')->find_many();
 
 #### Grouping ####
 

--- a/idiorm.php
+++ b/idiorm.php
@@ -749,9 +749,9 @@
         }
 
         /**
-         * Add a raw ORDER BY clause
+         * Add an unquoted expression as an ORDER BY clause
          */
-        public function order_raw($clause) {
+        public function order_by_expr($clause) {
             $this->_order_by[] = $clause;
             return $this;
         }

--- a/test/test_queries.php
+++ b/test/test_queries.php
@@ -80,9 +80,9 @@
     $expected = "SELECT * FROM `widget` ORDER BY `name` ASC LIMIT 1";
     Tester::check_equal("ORDER BY ASC", $expected);
 
-    ORM::for_table('widget')->order_raw('SOUNDEX(`name`)')->find_one();
+    ORM::for_table('widget')->order_by_expr('SOUNDEX(`name`)')->find_one();
     $expected = "SELECT * FROM `widget` ORDER BY SOUNDEX(`name`) LIMIT 1";
-    Tester::check_equal("Raw ORDER BY", $expected);
+    Tester::check_equal("ORDER BY expression", $expected);
 
     ORM::for_table('widget')->order_by_asc('name')->order_by_desc('age')->find_one();
     $expected = "SELECT * FROM `widget` ORDER BY `name` ASC, `age` DESC LIMIT 1";


### PR DESCRIPTION
This change adds support for adding raw `ORDER BY` clauses. The `order_by_asc` and `order_by_desc` methods do not escape, but they do quote their parameters. This prevents you from ordering by the result of an SQL function for example. The `order_raw` method makes this possible.
