### PR TITLE
Support for raw queries without parameters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -297,7 +297,7 @@ The `join` methods also take an optional third parameter, which is an `alias` fo
 
 #### Raw queries ####
 
-If you need to perform more complex queries, you can completely specify the query to execute by using the `raw_query` method. This method takes a string and an array of parameters. The string should contain placeholders, either in question mark or named placeholder syntax, which will be used to bind the parameters to the query.
+If you need to perform more complex queries, you can completely specify the query to execute by using the `raw_query` method. This method takes a string and optionally an array of parameters. The string can contain placeholders, either in question mark or named placeholder syntax, which will be used to bind the parameters to the query.
 
     $people = ORM::for_table('person')->raw_query('SELECT p.* FROM person p JOIN role r ON p.role_id = r.id WHERE r.name = :role', array('role' => 'janitor')->find_many();
 

--- a/idiorm.php
+++ b/idiorm.php
@@ -411,13 +411,13 @@
         }
 
         /**
-         * Perform a raw query. The query should contain placeholders,
-         * in either named or question mark style, and the parameters
-         * should be an array of values which will be bound to the
-         * placeholders in the query. If this method is called, all
-         * other query building methods will be ignored.
+         * Perform a raw query. The query can contain placeholders in
+         * either named or question mark style. If placeholders are
+         * used, the parameters should be an array of values which will
+         * be bound to the placeholders in the query. If this method
+         * is called, all other query building methods will be ignored.
          */
-        public function raw_query($query, $parameters) {
+        public function raw_query($query, $parameters = array()) {
             $this->_is_raw_query = true;
             $this->_raw_query = $query;
             $this->_raw_parameters = $parameters;

--- a/test/test_queries.php
+++ b/test/test_queries.php
@@ -124,9 +124,13 @@
     $expected = "SELECT * FROM `widget` WHERE `age` = '18' AND (`name` = 'Fred' OR `name` = 'Bob') AND `size` = 'large'";
     Tester::check_equal("Raw WHERE clause in method chain", $expected);
 
+    ORM::for_table('widget')->raw_query('SELECT `w`.* FROM `widget` w')->find_many();
+    $expected = "SELECT `w`.* FROM `widget` w";
+    Tester::check_equal("Raw query", $expected);
+
     ORM::for_table('widget')->raw_query('SELECT `w`.* FROM `widget` w WHERE `name` = ? AND `age` = ?', array('Fred', 5))->find_many();
     $expected = "SELECT `w`.* FROM `widget` w WHERE `name` = 'Fred' AND `age` = '5'";
-    Tester::check_equal("Raw query", $expected);
+    Tester::check_equal("Raw query with parameters", $expected);
 
     ORM::for_table('widget')->select('name')->find_many();
     $expected = "SELECT `name` FROM `widget`";


### PR DESCRIPTION
This change adds support for raw queries without parameters. Using this you can execute e.g. MySQL `LOCK TABLE` statements or Sqlite `VACUUM` statements.
