### PR TITLE
configure() function can now accept an array of settings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -391,6 +391,10 @@ Other than setting the DSN string for the database connection (see above), the `
 
     ORM::configure('setting_name', 'value_for_setting');
 
+A shortcut is provided to allow passing multiple key/value pairs at once.
+
+    ORM::configure(array('setting_name_1' => 'value_for_setting_1', 'setting_name_2' => 'value_for_setting_2', 'etc' => 'etc'));
+
 #### Database authentication details ####
 
 Settings: `username` and `password`
@@ -400,6 +404,10 @@ Some database adapters (such as MySQL) require a username and password to be sup
     ORM::configure('mysql:host=localhost;dbname=my_database');
     ORM::configure('username', 'database_user');
     ORM::configure('password', 'top_secret');
+
+Or you can combine the connection setup into a single line using the configuration array shortcut:
+
+    ORM::configure(array('connection_string' => 'mysql:host=localhost;dbname=my_database', 'username' => 'database_user', 'password' => 'top_secret'));
 
 #### PDO Driver Options ####
 

--- a/idiorm.php
+++ b/idiorm.php
@@ -148,18 +148,29 @@
         /**
          * Pass configuration settings to the class in the form of
          * key/value pairs. As a shortcut, if the second argument
-         * is omitted, the setting is assumed to be the DSN string
-         * used by PDO to connect to the database. Often, this
-         * will be the only configuration required to use Idiorm.
+         * is omitted and the key is a string, the setting is
+         * assumed to be the DSN string used by PDO to connect
+         * to the database (often, this will be the only configuration
+         * required to use Idiorm). If you have more than one setting
+         * you wish to configure, another shortcut is to pass an array
+         * of settings (and omit the second argument).
          */
         public static function configure($key, $value=null) {
-            // Shortcut: If only one argument is passed, 
-            // assume it's a connection string
-            if (is_null($value)) {
-                $value = $key;
-                $key = 'connection_string';
+            if (is_array($key)) {
+                // Shortcut: If only one array argument is passed,
+                // assume it's an array of configuration settings
+                foreach ($key as $one_key => $one_value) {
+                    self::configure($one_key, $one_value);
+                }
+            } else {
+                if (is_null($value)) {
+                    // Shortcut: If only one string argument is passed, 
+                    // assume it's a connection string
+                    $value = $key;
+                    $key = 'connection_string';
+                }
+                self::$_config[$key] = $value;
             }
-            self::$_config[$key] = $value;
         }
 
         /**


### PR DESCRIPTION
Howdy,
I love idiorm because it's so lightweight and there's just 1 include line at the top of my code. Hence I find it bothersome that when using with MySQL I need 3 lines for the configuration. Also I've found idiorm is a great library to use when teaching people PHP because it lets you ignore SQL for a while (things are confusing enough as it is!) -- but again, having the 3 line config is very distracting, as well as error-prone when I want to have them create a new file and copy/paste the db connection info into it.

So I know the syntax is ugly, but I personally prefer 1 ugly line that can be pretty much ignored as opposed to 3 lines that start to look like something you should pay attention to (which you shouldn't because it's just db connection stuff, not application logic).

Thanks for your consideration.

   -Jordan
