### PR TITLE
modification to mark field as dirty on real value change

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1027,8 +1027,10 @@
          * database when save() is called.
          */
         public function set($key, $value) {
+            // field is dirty only if value change
+    		if($value!==$this->_data[$key])
+	            $this->_dirty_fields[$key] = $value;
             $this->_data[$key] = $value;
-            $this->_dirty_fields[$key] = $value;
         }
 
         /**


### PR DESCRIPTION
Just a little modification to mark field as dirty only if a real change was made.

=> You can set value in all field without make data compare (great for massive field update) and the resulting SQL query contain only real changes

=> Also usefull to detect real change beafore calling save method

PS : A possibility to call is_dirty without argument and check in all field in a row will be great
