### PR TITLE
Handle ambiguous column names when JOINing tables

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -580,6 +580,10 @@
          * of the call to _quote_identifier
          */
         protected function _add_simple_where($column_name, $separator, $value) {
+            // Add the table name in case of ambiguous columns
+            if (count($this->_join_sources) > 0 && strpos($column_name, '.') === false) {
+                $column_name = "{$this->_table_name}.{$column_name}";
+            }
             $column_name = $this->_quote_identifier($column_name);
             return $this->_add_where("{$column_name} {$separator} ?", $value);
         }

--- a/test/test_queries.php
+++ b/test/test_queries.php
@@ -152,6 +152,10 @@
     $expected = "SELECT * FROM `widget` JOIN `widget_handle` ON `widget_handle`.`widget_id` = `widget`.`id`";
     Tester::check_equal("Simple join", $expected);
 
+    ORM::for_table('widget')->join('widget_handle', array('widget_handle.widget_id', '=', 'widget.id'))->find_one(5);
+    $expected = "SELECT * FROM `widget` JOIN `widget_handle` ON `widget_handle`.`widget_id` = `widget`.`id` WHERE `widget`.`id` = '5' LIMIT 1";
+    Tester::check_equal("Simple join with where_id_is method", $expected);
+
     ORM::for_table('widget')->inner_join('widget_handle', array('widget_handle.widget_id', '=', 'widget.id'))->find_many();
     $expected = "SELECT * FROM `widget` INNER JOIN `widget_handle` ON `widget_handle`.`widget_id` = `widget`.`id`";
     Tester::check_equal("Inner join", $expected);


### PR DESCRIPTION
I ran across a problem with Idiorm (great library BTW) when joining two tables via an intermediate join table (i.e. `has_many_through()`). Here is my setup (this isn't my exact setup - i tried to simplify for illustration). `Users` have many `Products`:

<pre>
User
====
user_id ...

User_Products
============
user_id ...
product_id ...

Product
=======
product_id ...
</pre>


I have this line in my User class (using Paris):

```
return $this->has_many_through('Product', 'User_Product', 'user_id', 'product_id');
```

Executing this (in Paris):

```
$product = $user->products()->find_one(5);
```

gives me a constraint violation due to ambiguous column names. The Idiorm generated query is:

```
SELECT `product`.* FROM `product` JOIN `user_products` ON `product`.`product_id` = `user_products`.`product_id` WHERE `user_products`.`user_id` = ? AND `product_id` = ? LIMIT 1
```

This pull request contains changes to add the table name to the ambiguous column name. I added a test for this scenario, though it doesn't really make sense in the test as there are only two tables. The remaining tests all still pass.
- `idiorm.php`: prepend table_name when in a WHERE clause
- `test_queries.php`: add test joining two tables with WHERE clause
