### PR TITLE
Added ability to have find_many return a simple array

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -374,8 +374,11 @@
          * of instances of the ORM class, or an empty array if
          * no rows were returned.
          */
-        public function find_many() {
+        public function find_many($pureArray = false) {
             $rows = $this->_run();
+            if ($pureArray) {
+                return $rows;
+            }
             return array_map(array($this, '_create_instance_from_row'), $rows);
         }
 


### PR DESCRIPTION
I find this very useful for using idiorm as part of a RESTful service as all I need most of the time is a simple multidimensional array I can call json_encode() on. Having to convert the array of models back into raw data is a for loop taht can be avoided since the raw data is originally fetched as an array.

To make it compatible Paris would also need the following

```
    /**
     * Wrap Idiorm's find_many method to return
     * an array of instances of the class associated
     * with this wrapper instead of the raw ORM class.
     */
   public function find_many($pureArray = false) {
        $rows = parent::find_many($pureArray);
        if($pureArray) {
            return $rows;
        }
        return array_map(array($this, '_create_model_instance'),$rows);
    }
```
