### PR TITLE
Fix last insert ID not being returned with postgresql.

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1040,6 +1040,20 @@
         }
 
         /**
+         * Returns lastInsertId(), taking PostgreSQL in account.
+         */
+        public function last_insert_id() {
+            switch(self::$_db->getAttribute(PDO::ATTR_DRIVER_NAME)) {
+                case 'pgsql':
+                    $this->_data[$this->_get_id_column_name()] = self::$_db->query('SELECT LASTVAL()')->fetchColumn();
+                    break;
+                default:
+                    $this->_data[$this->_get_id_column_name()] = self::$_db->lastInsertId();;
+            }
+            return $this->_data[$this->_get_id_column_name()];
+        }
+
+        /**
          * Save any fields which have been modified on this object
          * to the database.
          */
@@ -1066,7 +1080,7 @@
             if ($this->_is_new) {
                 $this->_is_new = false;
                 if (is_null($this->id())) {
-                    $this->_data[$this->_get_id_column_name()] = self::$_db->lastInsertId();
+                    $this->_data[$this->_get_id_column_name()] = self::last_insert_id();
                 }
             }
 


### PR DESCRIPTION
When using PostgreSQL, upon saving new entries id is not being updated. 

That's because [PDO's implementation](http://lv.php.net/manual/en/pdo.lastinsertid.php) of lastInsertId requires sequence name as a parameter. One of three available options is fetching LASTVAL(). All three are described in the answer to [this SO question](http://stackoverflow.com/questions/2944297/postgresql-function-for-last-inserted-id).

I 'fixed' it by adding driver specific last_insert_id() method to ORM class.
