### PR TITLE
Fix bug where input parameters were sent as part-indexed, part associati...

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1267,7 +1267,7 @@
             $query = array();
 
             // remove any expression fields as they are already baked into the query
-            $values = array_diff_key($this->_dirty_fields, $this->_expr_fields);
+            $values = array_values(array_diff_key($this->_dirty_fields, $this->_expr_fields));
 
             if (!$this->_is_new) { // UPDATE
                 // If there are no dirty values, do nothing


### PR DESCRIPTION
...ve array

Hello,

Thanks for taking over the project. I updated idiorm with great anticipation and ran into an error on a simple update. Taking the example from the test, the following code:

```
$widget = ORM::for_table('widget')->find_one(1);
$widget->name = "Fred";
$widget->age = 10;
$widget->save();
```

passes the test because it is not actually executed. Upon execution, I get the following error:

```
SQLSTATE[HY093]: Invalid parameter number: parameter was not defined
```

If I dump out the input parameters sent to `execute()` (line 1285), I get:

```
array(3) {
  'name' => string(4) "Fred"
  'age' => int(10)
  [0] => string(1) "1"
}
```

PDO does not seem to like the mix of named and indexed parameters. This PR fixes this so that the input parameters are all indexed array values.

Gerard
