### PR TITLE
Allow subclasses to set their own $_config property

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ Idiorm
 
 A lightweight nearly-zero-configuration object-relational mapper and fluent query builder for PHP5.
 
-Tested on PHP 5.2.0+ - may work on earlier versions with PDO and the correct database drivers.
+Tested on PHP 5.3.0+.
 
 Released under a [BSD license](http://en.wikipedia.org/wiki/BSD_licenses).
 
@@ -71,7 +71,7 @@ Changelog
 Philosophy
 ----------
 
-The [Pareto Principle](http://en.wikipedia.org/wiki/Pareto_principle) states that *roughly 80% of the effects come from 20% of the causes.* In software development terms, this could be translated into something along the lines of *80% of the results come from 20% of the complexity*. In other words, you can get pretty far by being pretty stupid. 
+The [Pareto Principle](http://en.wikipedia.org/wiki/Pareto_principle) states that *roughly 80% of the effects come from 20% of the causes.* In software development terms, this could be translated into something along the lines of *80% of the results come from 20% of the complexity*. In other words, you can get pretty far by being pretty stupid.
 
 **Idiorm is deliberately simple**. Where other ORMs consist of dozens of classes with complex inheritance hierarchies, Idiorm has only one class, `ORM`, which functions as both a fluent `SELECT` query API and a simple CRUD model class. If my hunch is correct, this should be quite enough for many real-world applications. Let's face it: most of us aren't building Facebook. We're working on small-to-medium-sized projects, where the emphasis is on simplicity and rapid development rather than infinite flexibility and features.
 
@@ -119,7 +119,7 @@ Also see "Configuration" section below.
 
 Idiorm provides a [*fluent interface*](http://en.wikipedia.org/wiki/Fluent_interface) to enable simple queries to be built without writing a single character of SQL. If you've used [jQuery](http://jquery.com) at all, you'll be familiar with the concept of a fluent interface. It just means that you can *chain* method calls together, one after another. This can make your code more readable, as the method calls strung together in order can start to look a bit like a sentence.
 
-All Idiorm queries start with a call to the `for_table` static method on the ORM class. This tells the ORM which table to use when making the query. 
+All Idiorm queries start with a call to the `for_table` static method on the ORM class. This tells the ORM which table to use when making the query.
 
 *Note that this method **does not** escape its query parameter and so the table name should **not** be passed directly from user input.*
 
@@ -530,8 +530,8 @@ Other than setting the DSN string for the database connection (see above), the `
 A shortcut is provided to allow passing multiple key/value pairs at once.
 
     ORM::configure(array(
-        'setting_name_1' => 'value_for_setting_1', 
-        'setting_name_2' => 'value_for_setting_2', 
+        'setting_name_1' => 'value_for_setting_1',
+        'setting_name_2' => 'value_for_setting_2',
         'etc' => 'etc'
     ));
 
@@ -548,8 +548,8 @@ Some database adapters (such as MySQL) require a username and password to be sup
 Or you can combine the connection setup into a single line using the configuration array shortcut:
 
     ORM::configure(array(
-        'mysql:host=localhost;dbname=my_database', 
-        'username' => 'database_user', 
+        'mysql:host=localhost;dbname=my_database',
+        'username' => 'database_user',
         'password' => 'top_secret'
     ));
 

--- a/idiorm.php
+++ b/idiorm.php
@@ -163,16 +163,16 @@
                 // Shortcut: If only one array argument is passed,
                 // assume it's an array of configuration settings
                 foreach ($key as $conf_key => $conf_value) {
-                    self::configure($conf_key, $conf_value);
+                    static::configure($conf_key, $conf_value);
                 }
             } else {
                 if (is_null($value)) {
-                    // Shortcut: If only one string argument is passed, 
+                    // Shortcut: If only one string argument is passed,
                     // assume it's a connection string
                     $value = $key;
                     $key = 'connection_string';
                 }
-                self::$_config[$key] = $value;
+                static::$_config[$key] = $value;
             }
         }
 
@@ -407,7 +407,7 @@
          * @return array
          */
         public function find_array() {
-            return $this->_run(); 
+            return $this->_run();
         }
 
         /**
@@ -552,14 +552,14 @@
          * Add columns to the list of columns returned by the SELECT
          * query. This defaults to '*'. Many columns can be supplied
          * as either an array or as a list of parameters to the method.
-         * 
+         *
          * Note that the alias must not be numeric - if you want a
          * numeric alias then prepend it with some alpha chars. eg. a1
-         * 
+         *
          * @example select_many(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5');
          * @example select_many('column', 'column2', 'column3');
          * @example select_many(array('column', 'column2', 'column3'), 'column4', 'column5');
-         * 
+         *
          * @return \ORM
          */
         public function select_many() {
@@ -578,16 +578,16 @@
 
         /**
          * Add an unquoted expression to the list of columns returned
-         * by the SELECT query. Many columns can be supplied as either 
+         * by the SELECT query. Many columns can be supplied as either
          * an array or as a list of parameters to the method.
-         * 
+         *
          * Note that the alias must not be numeric - if you want a
          * numeric alias then prepend it with some alpha chars. eg. a1
-         * 
+         *
          * @example select_many_expr(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5')
          * @example select_many_expr('column', 'column2', 'column3')
          * @example select_many_expr(array('column', 'column2', 'column3'), 'column4', 'column5')
-         * 
+         *
          * @return \ORM
          */
         public function select_many_expr() {
@@ -607,11 +607,11 @@
         /**
          * Take a column specification for the select many methods and convert it
          * into a normalised array of columns and aliases.
-         * 
+         *
          * It is designed to turn the following styles into a normalised array:
-         * 
+         *
          * array(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5'))
-         * 
+         *
          * @param array $columns
          * @return array
          */
@@ -944,7 +944,7 @@
         }
 
         /**
-         * Add an unquoted expression to the list of columns to GROUP BY 
+         * Add an unquoted expression to the list of columns to GROUP BY
          */
         public function group_by_expr($expr) {
             $this->_group_by[] = $expr;


### PR DESCRIPTION
Allow subclasses to set their own $_config property via configure (requires PHP 5.3), required by j4mie/paris#33. 

Bumped PHP requirement in readme.
