### PR TITLE
Added a none function that guarantees an empty set.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -241,6 +241,19 @@ Note that this method only supports "question mark placeholder" syntax, and NOT 
 
 If you require yet more flexibility, you can manually specify the entire query. See *Raw queries* below.
 
+##### Empty sets #####
+
+Occasionally you may find you need to always return an empty set. This could be useful when validating non-database values but an instance of ORM needs to be returned (e.g. a custom Paris filter).
+
+    $people = ORM::for_table('person')->none()->find_many();
+
+    // Creates SQL:
+    SELECT * FROM `person` WHERE 0;
+
+Note: By default if a none function is present in the chain the query will never actually be run against the database (although the query will still be logged). This behaviour can be changed by setting the `optimise_none` config to `false`:
+
+    ORM::configure('optimise_none', false);
+
 ##### Limits and offsets #####
 
 *Note that these methods **do not** escape their query parameters and so these should **not** be passed directly from user input.*

--- a/idiorm.php
+++ b/idiorm.php
@@ -64,6 +64,7 @@
             'identifier_quote_character' => null, // if this is null, will be autodetected
             'logging' => false,
             'caching' => false,
+            'optimise_none' => true,
         );
 
         // Database connection, instance of the PDO class
@@ -143,6 +144,10 @@
         // Name of the column to use as the primary key for
         // this instance only. Overrides the config settings.
         protected $_instance_id_column = null;
+
+        // Whether the none function has been used.
+        // Allows us to avoid querying the database.
+        protected $_none = false;
 
         // ---------------------- //
         // --- STATIC METHODS --- //
@@ -601,6 +606,17 @@
                     $this->select_expr($column, $alias);
                 }
             }
+            return $this;
+        }
+
+        /**
+         * Makes sure that an empty set is returned by the ORM
+         *
+         * @return \ORM
+         */
+        public function none() {
+            $this->_none = true;
+            $this->where_raw(0);
             return $this;
         }
 
@@ -1145,6 +1161,7 @@
         protected function _run() {
             $query = $this->_build_select();
             $caching_enabled = self::$_config['caching'];
+            $none_optimised = self::$_config['optimise_none'];
 
             if ($caching_enabled) {
                 $cache_key = self::_create_cache_key($query, $this->_values);
@@ -1156,12 +1173,15 @@
             }
 
             self::_log_query($query, $this->_values);
-            $statement = self::$_db->prepare($query);
-            $statement->execute($this->_values);
 
             $rows = array();
-            while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-                $rows[] = $row;
+            if (!($none_optimised && $this->_none)) {
+                $statement = self::$_db->prepare($query);
+                $statement->execute($this->_values);
+
+                while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+                    $rows[] = $row;
+                }
             }
 
             if ($caching_enabled) {

--- a/test/test_queries.php
+++ b/test/test_queries.php
@@ -80,6 +80,10 @@
     $expected = "SELECT * FROM `widget` WHERE `name` NOT IN ('Fred', 'Joe')";
     Tester::check_equal("where_not_in method", $expected);
 
+    ORM::for_table('widget')->none()->find_many();
+    $expected = "SELECT * FROM `widget` WHERE 0";
+    Tester::check_equal("None function", $expected);
+
     ORM::for_table('widget')->limit(5)->find_many();
     $expected = "SELECT * FROM `widget` LIMIT 5";
     Tester::check_equal("LIMIT clause", $expected);


### PR DESCRIPTION
Hi,

I added a function.

``` php
ORM::for_table('people')->none()->find_many();
```

That is guaranteed to return an empty set. This code devolves down to the following query:

``` sql
SELECT * FROM `person` WHERE 0;
```

The reasons for having a dedicated function are:
- Syntatic sugar: `none` or a similarly named function makes more sense than `where_raw(0)`
- Possibility to optimise (by not actually executing the query)

An example use of this code in Paris would be:

``` php
class User extends Model {

    public static function has_cookie($orm, $cookie_name) {
        if (isset($_COOKIE[$cookie_name]))  {
            $cookie = $_COOKIE[$cookie_name];
            return $orm->where('cookie', $cookie);
        }
        // Return empty set
        //return $orm->where_raw(0);
        return $orm->none();
    }

}

$users = Model::Factory('user')->filter('has_cookie', 'user')->find_many();
```
