### PR TITLE
Fixing minor code typo in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -458,7 +458,7 @@ To update the database, change one or more of the properties of the object, then
 
 It is possible to set properties on the model that contain database expressions using the `set_expr` method.
 
-    $person = ORM::for_table('person')->find_one(5);;
+    $person = ORM::for_table('person')->find_one(5);
     $person->set('name', 'Bob Smith');
     $person->age = 20;
     $person->set_expr('updated', 'NOW()');


### PR DESCRIPTION
Sorry to be nitpicky. Removing a double semicolon in the set_expr example.
