### PR TITLE
Int often not enough when returning number from Aggregate functions

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -465,7 +465,9 @@
             }
             $this->select_expr("$sql_function($column)", $alias);
             $result = $this->find_one();
-            return ($result !== false && isset($result->$alias)) ? (int) $result->$alias : 0;
+            if($result !== false && isset($result->$alias)) {
+                return ((int) $result->$alias == floatval($result->$alias)) ? (int) $result->$alias : floatval($result->$alias);
+            } else { return 0; }
         }
 
          /**


### PR DESCRIPTION
So, I don't know that anything besides an int and a float are necessary for some of these functions, but int was _definitely_ too limiting.

> My AVG() isn't 21, it's 21.5!
