### PR TITLE
Change autoload option to classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,6 @@
         "php": ">=5.2.0"
     },
     "autoload": {
-        "files": ["idiorm.php"]
+        "classmap": ["idiorm.php"]
     }
 }


### PR DESCRIPTION
Instead of requiring the file explicitly on every request the classmap option allows to load the class on-demand
