### PR TITLE
reset so that we can call find_many after count

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1168,6 +1168,11 @@
                 self::_cache_query_result($cache_key, $rows);
             }
 
+            // reset
+            $this->_values = array();
+            $this->_result_columns = array('*');
+            $this->_using_default_result_columns = true;
+
             return $rows;
         }
 


### PR DESCRIPTION
Hi

it's a very common case.

we use

$orm = ORM::for_table('table');

// then we build complicated where.

then we count first

$total = $orm->count();

if total  > 0, we then select with a limit.

$xxx = $orm->limit(50)->offset(10)->find_many();

or we call find_many first, then we call count on those build complicated where.

the patch will reset the _values and _result_columns so that the case will work. right now it is broken because the _values will be pushed twice. and COUNT(*) will stay on find_many.

Thanks.
