### PR TITLE
Fixed a minor typo in the example of the select_many() function

### DIFF
--- a/docs/querying.rst
+++ b/docs/querying.rst
@@ -455,7 +455,7 @@ key in an associative array):
 
 ::
 
-    $people = ORM::for_table('person')->select_many(array('first_name' => 'name', 'age'), 'height')->find_many();
+    $people = ORM::for_table('person')->select_many(array('first_name' => 'name'), 'age', 'height')->find_many();
 
 Will result in the query:
 


### PR DESCRIPTION
Pretty self-explanatory. 
