### PR TITLE
there is a bug if enable query cache

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1494,6 +1494,7 @@
                 $cached_result = self::_check_query_cache($cache_key, $this->_connection_name);
 
                 if ($cached_result !== false) {
+                    $this->reset();
                     return $cached_result;
                 }
             }
@@ -1511,13 +1512,20 @@
             }
 
             // reset Idiorm after executing the query
-            $this->_values = array();
-            $this->_result_columns = array('*');
-            $this->_using_default_result_columns = true;
+            $this->reset();
 
             return $rows;
         }
-
+        
+        /**
+         * reset Idiorm after executing the query
+         */
+        protected function reset(){
+            $this->_values = array();
+            $this->_result_columns = array('*');
+            $this->_using_default_result_columns = true;
+        }        
+        
         /**
          * Return the raw data wrapped by this ORM
          * instance as an associative array. Column


### PR DESCRIPTION
after hit cache,idiorm must be reset,if not ,next time ,$this->_value will be wrong.
