### PR TITLE
[improvement] find_many returns an associative array

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -718,8 +718,8 @@
          */
         public function select($column, $alias=null) {
             $columns = array_map('trim',explode(',',$column));
-            foreach($columns as $key=>$column){
-                $columns[$key] = $this->_quote_identifier($column);
+            foreach($columns as $column){
+                $column = $this->_quote_identifier($column);
                 $this->_add_result_column($column, $alias);
             }
             return $this;


### PR DESCRIPTION
Pull based on https://github.com/j4mie/idiorm/issues/132

Added find_many return associative keys. 
Micro optimizations for Idiorm and Paris.
set and set_expr returns the instance, to admit a fluent query
