### PR TITLE
Handle dirty field more accurately

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1596,8 +1596,13 @@
                 $key = array($key => $value);
             }
             foreach ($key as $field => $value) {
+
+                // dirty field only in case of real change
+                if(!isset($this->_data[$field]) || $this->_data[$field]!==$value)
+                    $this->_dirty_fields[$field] = $value;
+                    
                 $this->_data[$field] = $value;
-                $this->_dirty_fields[$field] = $value;
+                
                 if (false === $expr and isset($this->_expr_fields[$field])) {
                     unset($this->_expr_fields[$field]);
                 } else if (true === $expr) {


### PR DESCRIPTION
Mark field as dirty only in real change case would be better

In my cas I have a loop which set attribute on object
But after this initial loop some extra action are applyed and some of them are triggered only on dirty fields ... I could make the test in my loop but I think it will be better in the ORM class

In my mind Dirty field is a field that is changed from it original value and if a set action replace a value with the exact same value the dirty flag has no reason to bet set

Hope this minor update will be merge
