### PR TITLE
Don't assume connection is available in ORM::save

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1643,6 +1643,7 @@
                 $query = $this->_build_insert();
             }
 
+            self::_setup_db($this->_connection_name);
             $success = self::_execute($query, $values, $this->_connection_name);
 
             // If we've just inserted a new record, set the ID of this object


### PR DESCRIPTION
If `ORM::save` is called before any other querying method and logging is enabled, logging will fail.
