### PR TITLE
Update bootstrap.php so the tests can run on both HHVM and Zend

### DIFF
--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -13,6 +13,14 @@ class MockPDOStatement extends PDOStatement {
    /**
     * Return some dummy data
     */
+   
+   /**
+    * These are necessary to run the tests on hhvm. In fact, newing up a PDOStatement (or derivative) should not be
+    * technically used since there is no direct constructor for PDOStatement, even though it does work with Zend
+    */
+   public function __construct() {}
+   public function execute($params) {}
+   
    public function fetch($fetch_style=PDO::FETCH_BOTH, $cursor_orientation=PDO::FETCH_ORI_NEXT, $cursor_offset=0) {
        if ($this->current_row == 5) {
            return false;


### PR DESCRIPTION
PDOStatement does not have a direct constructor (i.e., __construct). Newing up a PDOStatement or subclass (e.g., MockPDOStatement) does technically work in Zend, but HHVM throws. A correct way to have the code currently structured in bootstrap.php work correctly on both Zend and HHVM is provide a default constructor and execute method in MockPDOStatement. It would probably best long term to avoid newing up a PDOStatement and create the queries another way. But this works for now.
