### PR TITLE
Correct docblock type hint for set_db($db)

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -247,7 +247,7 @@
          * This is public in case the ORM should use a ready-instantiated
          * PDO object as its database connection. Accepts an optional string key
          * to identify the connection if multiple connections are used.
-         * @param ORM $db
+         * @param PDO $db
          * @param string $connection_name Which connection to use
          */
         public static function set_db($db, $connection_name = self::DEFAULT_CONNECTION) {


### PR DESCRIPTION
A very small error in the big scheme of things, but it's annoying to have the IDE constantly nagging me that I'm passing the wrong type.
