### PR TITLE
Improving typecasting for aggregate db functions

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -711,7 +711,10 @@
 
             $return_value = 0;
             if($result !== false && isset($result->$alias)) {
-                if((int) $result->$alias == (float) $result->$alias) {
+                if (!is_numeric($result->$alias)) {
+                    $return_value = $result->$alias;
+                }
+                elseif((int) $result->$alias == (float) $result->$alias) {
                     $return_value = (int) $result->$alias;
                 } else {
                     $return_value = (float) $result->$alias;


### PR DESCRIPTION
Some SQL aggregate functions (like [MAX()](http://dev.mysql.com/doc/refman/5.5/en/group-by-functions.html#function_max)) may take not numbers but strings. So typecasting returned value to int or float is not always correct.
