### PR TITLE
Added a method and validation for PostgreSQL 8.* compatibility

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1793,13 +1793,8 @@
     
                 $queryFinal = join(' ', $query);
     
-                self::_log_query($queryFinal, $parameters, $this->_connection_name);
-    
-                $statement = self::$_db[$this->_connection_name]->prepare($queryFinal);
-    
-                self::$_last_statement = $statement;
-    
-                return $statement->execute($parameters);
+                return self::_execute($queryFinal, $parameters, $this->_connection_name);
+                
             } else {
                 return null;
             }


### PR DESCRIPTION
Added a method and validation for PostgreSQL 8.\* compatibility using the same fields and values from the last insert as filters. PostgreSQL 8.\* doesn't have a RETURNING keyword.
The validation checks the current server version so we can skip this fix if we're using PostgreSQL 9+.
