### PR TITLE
Set associative array with a specified key manually

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -165,6 +165,12 @@
         // this instance only. Overrides the config settings.
         protected $_instance_id_column = null;
 
+        // Set a field as instance key
+        protected $_key_by = null;
+
+        // Put rows into a set with specified instance key?
+        protected $_row_set = false;
+
         // ---------------------- //
         // --- STATIC METHODS --- //
         // ---------------------- //
@@ -616,17 +622,38 @@
 
         /**
          * Create instances of each row in the result and map
-         * them to an associative array with the primary IDs as
+         * them to an associative array with the specified row field as
          * the array keys.
          * @param array $rows
          * @return array
          */
         protected function _instances_with_id_as_key($rows) {
             $instances = array();
-            foreach($rows as $row) {
-                $row = $this->_create_instance_from_row($row);
-                $instances[$row->id()] = $row;
+            if (is_null($this->_key_by) {
+                foreach($rows as $row) {
+                    $row = $this->_create_instance_from_row($row);
+                    $instances[] = $row;
+                }
+            } else if (!$this->_row_set) {
+                foreach($rows as $row) {
+                    $row = $this->_create_instance_from_row($row);
+                    $instances[$row->get($this->_key_by)] = $row;
+                }
+            } else {
+                foreach($rows as $row) {
+                    $row = $this->_create_instance_from_row($row);
+                    $instances[$row->get($this->_key_by)][] = $row;
+                }
             }
+            return $instances;
+        }
+
+        /**
+         * Specify array key
+         */
+        public function key_by ($key, $set = false) {
+            $this->_key_by = $key;
+            $this->_row_set = $set;
             return $instances;
         }
 


### PR DESCRIPTION
Hi there, thanks for your great job with 1.4.0.

`Returns array with primary ID as the keys` is a good idea, but it would be better if I can specify any field as a key ( and be more compatible with old version). So I made a function to do this named key_by (sorry for my poor English). And there are two notes:
1. Add another property _row_set , sometimes we need a set of row that group by a specified key.
2. I take `if statement` out of `for` in func _instances_with_id_as_key for performance reason.

Thank you.
