### PR TITLE
Changed database array access to ensure it's always properly setup

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -189,7 +189,7 @@
                 // Shortcut: If only one array argument is passed,
                 // assume it's an array of configuration settings
                 foreach ($key as $conf_key => $conf_value) {
-                    self::$_config[$connection_name][$conf_key] = $conf_value;
+                    self::configure($conf_key, $conf_value, $connection_name);
                 }
             } else {
                 if (is_null($value)) {


### PR DESCRIPTION
This solves my cached entries problem mentioned on issue #137 and probably also its authors problem. I was able to run the phpunit tests under PHP 5.5 with this fix too (it would throw initialization errors and not run with the master branch).

Details:
- Changed $_db access to ensure it's always properly setup
- Fixed typo on comment ('mulitple' -> 'multiple')
