### PR TITLE
Allow unsetting the db (ORM::set_db(null)) to make the test work agen

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -253,7 +253,9 @@
         public static function set_db($db, $connection_name = self::DEFAULT_CONNECTION) {
             self::_setup_db_config($connection_name);
             self::$_db[$connection_name] = $db;
-            self::_setup_identifier_quote_character($connection_name);
+            if(!is_null($db)) {
+            	self::_setup_identifier_quote_character($connection_name);
+            }
         }
 
         /**


### PR DESCRIPTION
the test was failing in tear down
https://github.com/borrel/idiorm/blob/master/test/CacheTest.php#L24
