### PR TITLE
Add method that resets last SELECT statement conditions

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1001,6 +1001,41 @@
             return $this;
         }
 
+        /**
+         * Delete all clauses and conditions like WHERE, HAVING, LIMIT, ORDER, etc.
+         * Usage:
+         *
+         * $brick = ORM::for_table('brick')->where('color', 'brown')->find_one();
+         *
+         * // ..use brick accordingly..
+         * // ..and then you can reset it and reuse without need to refactor:
+         *
+         * $brick->reset_conditions()->where('color', 'grey')->find_one();
+         *
+         */
+        public function reset_conditions() {
+
+          // WHERE clauses
+          $this->_where_conditions = array();
+
+          // LIMIT
+          $this->_limit = null;
+
+          // OFFSET
+          $this->_offset = null;
+
+          // ORDER BY
+          $this->_order_by = array();
+
+          // GROUP BY
+          $this->_group_by = array();
+
+          // HAVING
+          $this->_having_conditions = array();
+
+          return $this;
+        }
+
        /**
          * Helper method to compile a simple COLUMN SEPARATOR VALUE
          * style HAVING or WHERE condition into a string and value ready to


### PR DESCRIPTION
My use case (assuming [Paris](https://github.com/j4mie/paris) is used as an Active Record):

``` php
class Locale {
  private $loader;
  private $language;
  public function __construct( LocaleLoader $loader, $language = 'en' ) {
    $this->loader = $loader;
    $this->language = $language;
  }
  public function get($term) {
    return $this->loader->get_translation($term, $this->language);
  }
}

interface LocaleLoader {
  public function get_translation($term, $language);
}

class LocaleDBLoader implements LocaleLoader {
  private $term_model;
  public function __construct( ORM $term_model ) {
    $this->term_model = $term_model;
  }
  public function get_translation($term, $language) {
    return $this->term_model
                ->reset_conditions()
                ->where('term', $term)
                ->find_one()
                ->translations()
                ->where('langauge', $language)
                ->find_one();
  }
}

class Term extends Model {}

$loader = new LocaleDBLoader( Model::factory('Term') );
$locale = new Locale( $loader, 'ca' );
echo 'In Catalan book is "' . $locale->get('book') . '" and pen is "' . $locale->get('pen') . '"';
```

Without `reset_conditions()` SELECT query adds conditions every time a method is called which results in wrong results.

Hopefully that makes sense.
