### PR TITLE
querying instances of extended classes

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -559,7 +559,7 @@
          * array of data fetched from the database)
          */
         protected function _create_instance_from_row($row) {
-            $instance = self::for_table($this->_table_name, $this->_connection_name);
+            $instance = static::for_table($this->_table_name, $this->_connection_name);
             $instance->use_id_column($this->_instance_id_column);
             $instance->hydrate($row);
             return $instance;


### PR DESCRIPTION
if idiorm is used with paris (or other classes that extend ORM) querying should return instances of the extending class instead of ORM.
$user = Model::factory('User')->find_one($id);
and
$user = Model::factory('User')->create();
should both have ORMWrapper as $orm property. if self:: instead of static:: is used find_one() will set instance of ORM to the $orm property of the model instead of ORMWrapper.
