### PR TITLE
where_id_in() for selecting multiple records by primary key

### DIFF
--- a/docs/querying.rst
+++ b/docs/querying.rst
@@ -275,6 +275,12 @@ Respects the ID column specified in the config. If you are using a compound
 primary key, you must pass an array where the key is the column name. Columns
 that don't belong to the key will be ignored.
 
+Shortcut: ``where_id_in``
+'''''''''''''''''''''''''
+
+This helper method is similar to ``where_id_is`, but it expects an array of
+primary keys to be selected. It is compound primary keys aware.
+
 Less than / greater than: ``where_lt``, ``where_gt``, ``where_lte``, ``where_gte``
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 

--- a/idiorm.php
+++ b/idiorm.php
@@ -1172,6 +1172,18 @@
             return $filtered;
         }
 
+       /**
+         * Helper method that filters an array containing compound column/value
+         * arrays.
+         */
+        protected function _get_compound_id_column_values_array($values) {
+            $filtered = array();
+            foreach($values as $value) {
+                $filtered[] = $this->_get_compound_id_column_values($value);
+            }
+            return $filtered;
+        }
+
         /**
          * Add a WHERE column = value clause to your query. Each time
          * this is called in the chain, an additional WHERE will be
@@ -1247,6 +1259,18 @@
             }
             $query[] = "))";
             return $this->where_raw(join($query, ' '), $data);
+        }
+
+        /**
+         * Similar to where_id_is() but allowing multiple primary keys.
+         *
+         * If primary key is compound, only the columns that
+         * belong to they key will be used for the query
+         */
+        public function where_id_in($ids) {
+            return (is_array($this->_get_id_column_name())) ?
+                $this->where_any_is($this->_get_compound_id_column_values_array($ids)) :
+                $this->where_in($this->_get_id_column_name(), $ids);
         }
 
         /**

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -40,6 +40,12 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, ORM::get_last_query());
     }
 
+    public function testWhereIdIn() {
+        ORM::for_table('widget')->where_id_in(array(4, 5))->find_many();
+        $expected = "SELECT * FROM `widget` WHERE `id` IN ('4', '5')";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
     public function testSingleWhereClause() {
         ORM::for_table('widget')->where('name', 'Fred')->find_one();
         $expected = "SELECT * FROM `widget` WHERE `name` = 'Fred' LIMIT 1";
@@ -614,6 +620,15 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
         $record->save();
         $record->delete();
         $expected = "DELETE FROM `widget` WHERE `id1` = '10' AND `id2` = '20'";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testWhereIdInWithCompoundPrimaryKey() {
+        $record = ORM::for_table('widget')->use_id_column(array('id1', 'id2'));
+        $record->where_id_in(array(
+            array('id1' => 10, 'name' => 'Joe', 'id2' => 20),
+            array('id1' => 20, 'name' => 'Joe', 'id2' => 30)))->find_many();
+        $expected = "SELECT * FROM `widget` WHERE (( `id1` = '10' AND `id2` = '20' ) OR ( `id1` = '20' AND `id2` = '30' ))";
         $this->assertEquals($expected, ORM::get_last_query());
     }
 


### PR DESCRIPTION
This PR allows selecting multiple records by passing an array of primary keys.

I.e.:

``` php

    <?php
    $people = ORM::for_table('person')
                ->where_id_in(array(1, 5))
                ->find_many();

    // Creates SQL:
    SELECT * FROM `person` WHERE id IN (1,5);
```

It also supports compound primary keys:

``` php

    <?php
    $people = ORM::for_table('person_profile')
                ->use_id_column(array('person_id', 'profile_id'))
                ->where_id_is(array(
                    array('person_id' => '5', 'profile_id' => 10, 'bogus' => 'whatever'),
                    array('person_id' => '10', 'profile_id' => 10)))
                ->find_many();

    // Creates SQL:
    SELECT * FROM `person_profile` WHERE (( `person_id` = '5' AND `profile_id` = '10' ) OR
                                  ( `person_id` = '10' AND `profile_id` = '10' ));
```

Closes #199
