### PR TITLE
Replace hard coded 'ORM' from __callStatic

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -2197,7 +2197,7 @@
         {
             $method = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $name));
 
-            return call_user_func_array(array('ORM', $method), $arguments);
+            return call_user_func_array(array(get_called_class(), $method), $arguments);
         }
     }
 


### PR DESCRIPTION
Hello,

I had problems to call my method with camelCase, so I tweaked the __callStatic a bit.

The "idea" of my Db Class:

<pre>
class Redaxscript_Db extends ORM
{
    public static function for_prefix_table($table_name = null, $connection_name = self::DEFAULT_CONNECTION)
    {
        self::_setup_db($connection_name);
        return new self(Redaxscript_Config::get('prefix') . $table_name, array(), $connection_name);
    }
}
</pre>


Calling with camelCase did not work with your hard coded 'ORM' inside __callStatic:

<pre>
Redaxscript_Db::forPrefixTable(...);
</pre>


I know that get_called_class() needs PHP 5.3, but this is upon you to work arround to this because I'm not used to your coding styles und stuff.

Take care
