### PR TITLE
Fix autoincremented compound keys inserts

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -2027,7 +2027,7 @@
                         // if the primary key is compound, assign the last inserted id
                         // to the first column
                         if (is_array($column)) {
-                            $column = array_slice($column, 0, 1);
+                            $column = reset($column);
                         }
                         $this->_data[$column] = $db->lastInsertId();
                     }


### PR DESCRIPTION
When inserting new records on a autoincremented compound keys table, a
bug would prevent updating the autoincremented value.

Fixes #233

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/j4mie/idiorm/235)

<!-- Reviewable:end -->
