### PR TITLE
fixing links to the PHP documentation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -362,6 +362,6 @@ If you wish to use custom caching functions, you can set them from the configure
 
 .. _PDO documentation: http://php.net/manual/en/pdo.construct.php
 .. _the PDO documentation: http://www.php.net/manual/en/pdo.construct.php
-.. _the PDO set attribute documentation: http://uk2.php.net/manual/en/pdo.setattribute.php
+.. _the PDO set attribute documentation: http://php.net/manual/en/pdo.setattribute.php
 .. _PDOStatement documentation: http://www.php.net/manual/en/class.pdostatement.php
 .. _Memcached: http://www.memcached.org/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -361,7 +361,7 @@ If you wish to use custom caching functions, you can set them from the configure
 
 
 .. _PDO documentation: http://php.net/manual/en/pdo.construct.php
-.. _the PDO documentation: http://www.php.net/manual/en/pdo.construct.php
+.. _the PDO documentation: http://php.net/manual/en/pdo.construct.php
 .. _the PDO set attribute documentation: http://php.net/manual/en/pdo.setattribute.php
-.. _PDOStatement documentation: http://www.php.net/manual/en/class.pdostatement.php
+.. _PDOStatement documentation: http://php.net/manual/en/class.pdostatement.php
 .. _Memcached: http://www.memcached.org/


### PR DESCRIPTION
php.net recently changed their links a bit which results in a call to http://uk2.php.net/ to return a 404 error