### PR TITLE
Issue #224 having_id_is undefined variable $value

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1473,8 +1473,8 @@
          */
         public function having_id_is($id) {
             return (is_array($this->_get_id_column_name())) ?
-                $this->where($this->_get_compound_id_column_values($id), null) :
-                $this->where($this->_get_id_column_name(), $id);
+                $this->having($this->_get_compound_id_column_values($id), null) :
+                $this->having($this->_get_id_column_name(), $id);
         }
 
         /**


### PR DESCRIPTION
as commented on a7f20ee1b89123b68d47e9d17e9964c495c183d2, I would think that "where()" is more correct than "having()".

If you agree, I believe a pull-request is less work for you.
