### PR TITLE
Fix for ORM#is_dirty

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -1964,7 +1964,7 @@
          * object was saved.
          */
         public function is_dirty($key) {
-            return isset($this->_dirty_fields[$key]);
+            return array_key_exists($key, $this->_dirty_fields);
         }
 
         /**

--- a/test/ORMTest.php
+++ b/test/ORMTest.php
@@ -43,8 +43,14 @@ class ORMTest extends PHPUnit_Framework_TestCase {
     public function testIsDirty() {
         $model = ORM::for_table('test')->create();
         $this->assertFalse($model->is_dirty('test'));
-        
+
         $model = ORM::for_table('test')->create(array('test' => 'test'));
+        $this->assertTrue($model->is_dirty('test'));
+
+        $model->test = null;
+        $this->assertTrue($model->is_dirty('test'));
+
+        $model->test = '';
         $this->assertTrue($model->is_dirty('test'));
     }
 


### PR DESCRIPTION
Update ORM#is_dirty - swapped isset() for array_key_exists() - isset() will return false when fields have been set null.

Update ORMTest#testIsDirty - added tests for filed set to '' and null
