### PR TITLE
IdiormResultSet::as_array should behave like ORM::as_array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 php:
   - 5.2

--- a/idiorm.php
+++ b/idiorm.php
@@ -2346,11 +2346,19 @@
         }
 
         /**
-         * Get the current result set as an array
+         * Return the content of the result set
+         * as an array of associative arrays. Column
+         * names may optionally be supplied as arguments,
+         * if so, only those keys will be returned.
          * @return array
          */
         public function as_array() {
-            return $this->get_results();
+            $rows = array();
+            $args = func_get_args();
+            foreach($this->_results as $row) {
+                $rows[] = call_user_func_array(array($row, 'as_array'), $args);
+            }
+            return $rows;
         }
         
         /**

--- a/test/IdiormResultSetTest.php
+++ b/test/IdiormResultSetTest.php
@@ -35,10 +35,20 @@ class IdiormResultSetTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testAsArray() {
-        $result_set = array('item' => new stdClass);
-        $IdiormResultSet = new IdiormResultSet();
-        $IdiormResultSet->set_results($result_set);
-        $this->assertSame($IdiormResultSet->as_array(), $result_set);
+        $result_set = array(
+            'item' => ORM::for_table('test')->create(array('foo' => 1, 'bar' => 2)),
+            'item2' => ORM::for_table('test')->create(array('foo' => 3, 'bar' => 4))
+        );
+        $IdiormResultSet = new IdiormResultSet($result_set);
+
+        $this->assertEquals($IdiormResultSet->as_array(), array(
+            array('foo' => 1, 'bar' => 2),
+            array('foo' => 3, 'bar' => 4))
+        );
+        $this->assertEquals($IdiormResultSet->as_array('foo'), array(
+            array('foo' => 1),
+            array('foo' => 3))
+        );
     }
 
     public function testCount() {

--- a/test/ORMTest.php
+++ b/test/ORMTest.php
@@ -176,4 +176,11 @@ class ORMTest extends PHPUnit_Framework_TestCase {
             $this->assertEquals($e->getMessage(), 'Primary key ID contains null value(s)');
         }
     }
+
+    public function testAsArray() {
+        $model = ORM::for_table('test')->create(array('foo' => 1, 'bar' => 2));
+        $this->assertEquals($model->as_array(), array('foo' => 1, 'bar' => 2));
+        $this->assertEquals($model->as_array('foo'), array('foo' => 1));
+    }
+
 }


### PR DESCRIPTION
Hi! It's not really a new feature :angel: but I would have expected:
-  `$user = Model::factory('User')->find_one($id)->as_array()`
- `$user = Model::factory('User')->find_many()->as_array()`

to behave the same way (that is, to return an associative array, or an array of associative array in the latter), but it does not seem to be the case.

Or have I missed something?
