### PR TITLE
add missing require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "test": "phpunit"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "ext-pdo_sqlite": "*"
     },
     "license": [
         "BSD-2-Clause",


### PR DESCRIPTION
the php extension pdo_sqlite is actually required for development
(in order to successfully execute the unit-tests).

tested on debian Jessie 8.9
this would for example mean, that the following debian package
is required: apt-get install php5-sqlite