### PR TITLE
Update bound_query in logging

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -553,7 +553,7 @@
                 } else {
                     // named placeholders
                     foreach ($parameters as $key => $val) {
-                        $query = str_replace($key, $val, $query);
+                        $query = str_replace(':'.$key, ':'.$val, $query);
                     }
                     $bound_query = $query;
                 }


### PR DESCRIPTION
If we use

`select * from abc where id = :id`

and the parameters are:

`['id' => 5]`

the bound_query in the log will be:

`select * from abc where 5 = :5`

which is confusing, that's why a double colon ':' should be added on the replace string

thanks