### PR TITLE
Assign null to self::$_db on reset_db to ensure PDO closes the connections

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -361,9 +361,11 @@
         }
 
         /**
-         * Delete all registered PDO objects in _db array.
+         * Close and delete all registered PDO objects in _db array.
          */
         public static function reset_db() {
+            self::$_db = null;
+
             self::$_db = array();
         }
 


### PR DESCRIPTION
I discovered by running `SHOW PROCESSLIST` in MySQL that even though I executed `\ORM::reset_db()` the connections were still hanging and wouldn't be closed until MySQL closed them. This was causing `errno=32 Broken pipe` errors when using Idiorm with a long running script. Even though `self::$_db` is assigned a new array, not assigning `null` seems to make PDO try to reuse old connections, which had been closed by MySQL, causing the aforementioned `Broken pipe` error. To make sure PDO closes connections they must be set to `null`, from the docs:

> To close the connection, you need to destroy the object by ensuring that all remaining references to it are deleted—you do this by assigning NULL to the variable that holds the object.

Setting `self::$_db` to `null` before assigning a new array ensured that PDO did really close the connection on `\ORM::reset_db()` and I verified it on MySQL using `SHOW PROCESSLIST`, and by the absence of errors in my script.