### PR TITLE
Refactor join() to implode() as of warning in PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ install: |
   if [ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "5.4" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]; then
     composer require phpunit/phpunit 4.8 --dev --no-update
     composer install
-  if
+  fi
   if [ ${TRAVIS_PHP_VERSION:0:1} == "7" ]; then
     composer install
-  if
+  fi
 script: |
   if [ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]; then
     $X/phpunit --colors --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
   - hhvm
 env: PHPV=0
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 5.5
   - 7.0
   - 7.1
   - 7.2
@@ -12,8 +13,6 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
-      dist: precise
-    - php: 5.5
       dist: precise
     - php: 5.6
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       dist: precise
     - php: 5.4
       dist: precise
-    - php: 5.4
+    - php: 5.5
       dist: trusty
     - php: 5.6
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 7.3
   - 7.4snapshot
 matrix:
+  allow_failures:
+    - php: 7.4snapshot
   include:
     - php: 5.2
       dist: precise
@@ -18,7 +20,7 @@ matrix:
     - php: 5.6
       dist: trusty
 before_install: |
-  if [ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]; then
+  if [ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]; then
     pecl install phar
   fi
 install: |
@@ -36,7 +38,11 @@ install: |
     composer require phpunit/phpunit 6 --dev --no-update
     composer install
   fi
-  if [ ${TRAVIS_PHP_VERSION:0:1} == "7" ]; then
+  if [ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; then
+    composer install
+  fi
+  if [ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]; then
+    composer require phpunit/phpunit 8 --dev --no-update
     composer install
   fi
 script: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.5
   - 7.0
   - 7.1
   - 7.2
@@ -14,8 +13,10 @@ matrix:
       dist: precise
     - php: 5.4
       dist: precise
+    - php: 5.4
+      dist: trusty
     - php: 5.6
-      dist: precise
+      dist: trusty
 before_install: |
   if [ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]; then
     pecl install phar
@@ -29,6 +30,10 @@ install: |
   fi
   if [ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "5.4" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]; then
     composer require phpunit/phpunit 4.8 --dev --no-update
+    composer install
+  fi
+  if [ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]; then
+    composer require phpunit/phpunit 6 --dev --no-update
     composer install
   fi
   if [ ${TRAVIS_PHP_VERSION:0:1} == "7" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,45 @@
 language: php
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot
-  - hhvm
-env: PHPV=0
 matrix:
   include:
     - php: 5.2
       dist: precise
-      env: PHPV=52
     - php: 5.3
       dist: precise
     - php: 5.4
       dist: precise
+    - php: 5.5
+      dist: precise
+    - php: 5.6
+      dist: precise
 before_install: |
-  if [ "$PHPV" -eq 52 ]; then
+  if [ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]; then
     pecl install phar
   fi
 install: |
-  if [ "$PHPV" -ne 52 ]; then
-    composer install
-  else
-    # special handling for PHP 5.2 testing as there is no composer available
+  if [ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]; then
     export X="$HOME/.idiorm/bin"
     mkdir -p "$X"
     curl -sSfL https://github.com/treffynnon/php5.2-phpunit3.6.12-phar/releases/download/1.0.2/php52-phpunit.phar -o "$X/phpunit"
     chmod +x "$X/phpunit"
   fi
+  if [ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "5.4" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]; then
+    composer require phpunit/phpunit 4.8 --dev --no-update
+    composer install
+  if
+  if [ ${TRAVIS_PHP_VERSION:0:1} == "7" ]; then
+    composer install
+  if
 script: |
-  if [ "$PHPV" -ne 52 ]; then
-    composer run-script test -- --colors --coverage-text
-  else
-    # special handling for PHP 5.2 testing as there is no composer available
-    # we need phpunit-3.6.12, but there is no phar file for it so comment out for now
+  if [ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]; then
     $X/phpunit --colors --coverage-text
+  else
+    composer run-script test -- --colors --coverage-text
   fi
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.4
   - 5.6
   - 7.0
   - 7.1
@@ -15,6 +14,8 @@ matrix:
       dist: precise
       env: PHPV=52
     - php: 5.3
+      dist: precise
+    - php: 5.4
       dist: precise
 before_install: |
   if [ "$PHPV" -eq 52 ]; then

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "test": "phpunit -c ./phpunit.xml"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.2",
+        "phpunit/phpunit": "^7",
         "ext-pdo_sqlite": "*"
     },
     "license": [

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "test": "phpunit -c ./phpunit.xml"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^8.2",
         "ext-pdo_sqlite": "*"
     },
     "license": [

--- a/idiorm.php
+++ b/idiorm.php
@@ -1355,7 +1355,7 @@
                 }
             }
             $query[] = "))";
-            return $this->where_raw(join($query, ' '), $data);
+            return $this->where_raw(implode(' ', $query), $data);
         }
 
         /**
@@ -1663,7 +1663,7 @@
          */
         protected function _build_select_start() {
             $fragment = 'SELECT ';
-            $result_columns = join(', ', $this->_result_columns);
+            $result_columns = implode($this->_result_columns, ', ');
 
             if (!is_null($this->_limit) &&
                 self::$_config[$this->_connection_name]['limit_clause_style'] === ORM::LIMIT_STYLE_TOP_N) {
@@ -1690,7 +1690,7 @@
                 return '';
             }
 
-            return join(" ", $this->_join_sources);
+            return implode($this->_join_sources, ' ');
         }
 
         /**
@@ -1714,7 +1714,7 @@
             if (count($this->_group_by) === 0) {
                 return '';
             }
-            return "GROUP BY " . join(", ", $this->_group_by);
+            return "GROUP BY " . implode($this->_group_by, ', ');
         }
 
         /**
@@ -1735,7 +1735,7 @@
                 $this->_values = array_merge($this->_values, $condition[self::CONDITION_VALUES]);
             }
 
-            return strtoupper($type) . " " . join(" AND ", $conditions);
+            return strtoupper($type) . " " . implode($conditions, ' AND ');
         }
 
         /**
@@ -1745,7 +1745,7 @@
             if (count($this->_order_by) === 0) {
                 return '';
             }
-            return "ORDER BY " . join(", ", $this->_order_by);
+            return "ORDER BY " . implode($this->_order_by, ', ');
         }
 
         /**
@@ -1793,7 +1793,7 @@
                     $filtered_pieces[] = $piece;
                 }
             }
-            return join($glue, $filtered_pieces);
+            return implode($filtered_pieces, $glue);
         }
 
         /**
@@ -1804,7 +1804,7 @@
         protected function _quote_one_identifier($identifier) {
             $parts = explode('.', $identifier);
             $parts = array_map(array($this, '_quote_identifier_part'), $parts);
-            return join('.', $parts);
+            return implode($parts, '.');
         }
 
         /**
@@ -1816,7 +1816,7 @@
         protected function _quote_identifier($identifier) {
             if (is_array($identifier)) {
                 $result = array_map(array($this, '_quote_one_identifier'), $identifier);
-                return join(', ', $result);
+                return implode($result, ', ');
             } else {
                 return $this->_quote_one_identifier($identifier);
             }
@@ -1848,7 +1848,7 @@
             if(isset(self::$_config[$connection_name]['create_cache_key']) and is_callable(self::$_config[$connection_name]['create_cache_key'])){
                 return call_user_func_array(self::$_config[$connection_name]['create_cache_key'], array($query, $parameters, $table_name, $connection_name));
             }
-            $parameter_string = join(',', $parameters);
+            $parameter_string = implode($parameters, ',');
             $key = $query . ':' . $parameter_string;
             return sha1($key);
         }
@@ -2153,9 +2153,9 @@
                 }
                 $field_list[] = "{$this->_quote_identifier($key)} = $value";
             }
-            $query[] = join(", ", $field_list);
+            $query[] = implode($field_list, ', ');
             $this->_add_id_column_conditions($query);
-            return join(" ", $query);
+            return implode($query, ' ');
         }
 
         /**
@@ -2165,7 +2165,7 @@
             $query[] = "INSERT INTO";
             $query[] = $this->_quote_identifier($this->_table_name);
             $field_list = array_map(array($this, '_quote_identifier'), array_keys($this->_dirty_fields));
-            $query[] = "(" . join(", ", $field_list) . ")";
+            $query[] = "(" . implode($field_list, ', ') . ")";
             $query[] = "VALUES";
 
             $placeholders = $this->_create_placeholders($this->_dirty_fields);
@@ -2175,7 +2175,7 @@
                 $query[] = 'RETURNING ' . $this->_quote_identifier($this->_get_id_column_name());
             }
 
-            return join(" ", $query);
+            return implode($query, ' ');
         }
 
         /**
@@ -2187,7 +2187,7 @@
                 $this->_quote_identifier($this->_table_name)
             );
             $this->_add_id_column_conditions($query);
-            return self::_execute(join(" ", $query), is_array($this->id(true)) ? array_values($this->id(true)) : array($this->id(true)), $this->_connection_name);
+            return self::_execute(implode($query, ' '), is_array($this->id(true)) ? array_values($this->id(true)) : array($this->id(true)), $this->_connection_name);
         }
 
         /**

--- a/test/CacheTest53.php
+++ b/test/CacheTest53.php
@@ -32,7 +32,7 @@ class CacheTest53 extends PHPUnit_Framework_TestCase {
             $phpunit->assertEquals(true, is_array($parameters));
             $phpunit->assertEquals(true, is_string($connection));
             $phpunit->assertEquals('widget', $table_name);
-            $parameter_string = join(',', $parameters);
+            $parameter_string = implode($parameters, ',');
             $key = $query . ':' . $parameter_string;
             $my_key = 'some-prefix'.crc32($key);
             return $my_key;

--- a/test/bootstrap.compat.php
+++ b/test/bootstrap.compat.php
@@ -1,0 +1,5 @@
+<?php
+
+if (class_exists('\PHPUnit\Framework\TestCase')) {
+	class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,12 +5,11 @@ require_once dirname(__FILE__) . '/../idiorm.php';
 /**
  * Ugly workaround for modern phpunit to support old php versions
  */
-if (class_exists('\PHPUnit\Framework\TestCase') && version_compare(PHP_VERSION, '5.4') > -1) {
-	class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
-	{
+if (phpversion() < '5.3.0' ) {
+	if (class_exists('\PHPUnit\Framework\TestCase')) {
+		class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
 	}
 }
-
 /**
  *
  * Mock version of the PDOStatement class.

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,7 +5,7 @@ require_once dirname(__FILE__) . '/../idiorm.php';
 /**
  * Ugly workaround for modern phpunit to support old php versions
  */
-if (class_exists('\PHPUnit\Framework\TestCase')) {
+if (class_exists('\PHPUnit\Framework\TestCase') && version_compare(PHP_VERSION, '5.3') >= 0) {
 	class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
 	{
 	}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -2,6 +2,11 @@
 
 require_once dirname(__FILE__) . '/../idiorm.php';
 
+// ugly workaround for modern phpunit to support old php versions
+class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
+{
+}
+
 /**
  *
  * Mock version of the PDOStatement class.

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,11 +5,11 @@ require_once dirname(__FILE__) . '/../idiorm.php';
 /**
  * Ugly workaround for modern phpunit to support old php versions
  */
-if (phpversion() > '5.3.0') {
+try {
 	if (class_exists('\PHPUnit\Framework\TestCase')) {
 	   class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
 	}
-}
+} catch(Exception $exception ) {}
 
 /**
  *

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -2,8 +2,9 @@
 
 require_once dirname(__FILE__) . '/../idiorm.php';
 
-// ugly workaround for modern phpunit to support old php versions
-
+/**
+ * Ugly workaround for modern phpunit to support old php versions
+ */
 if (class_exists('\PHPUnit\Framework\TestCase')) {
 	class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
 	{

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -3,8 +3,11 @@
 require_once dirname(__FILE__) . '/../idiorm.php';
 
 // ugly workaround for modern phpunit to support old php versions
-class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
-{
+
+if (class_exists('\PHPUnit\Framework\TestCase')) {
+	class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
+	{
+	}
 }
 
 /**

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,11 +5,9 @@ require_once dirname(__FILE__) . '/../idiorm.php';
 /**
  * Ugly workaround for modern phpunit to support old php versions
  */
-try {
-	if (class_exists('\PHPUnit\Framework\TestCase')) {
-	   class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
-	}
-} catch(Exception $exception ) {}
+if (phpversion() > '5.3.0') {
+	include_once('bootstrap.compat.php');
+}
 
 /**
  *

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,11 +5,11 @@ require_once dirname(__FILE__) . '/../idiorm.php';
 /**
  * Ugly workaround for modern phpunit to support old php versions
  */
-if (phpversion() < '5.3.0' ) {
-	if (class_exists('\PHPUnit\Framework\TestCase')) {
-		class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
-	}
+if (phpversion() > '5.3.0' && class_exists('\PHPUnit\Framework\TestCase')) {
+   class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
 }
+
+
 /**
  *
  * Mock version of the PDOStatement class.

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,10 +5,11 @@ require_once dirname(__FILE__) . '/../idiorm.php';
 /**
  * Ugly workaround for modern phpunit to support old php versions
  */
-if (phpversion() > '5.3.0' && class_exists('\PHPUnit\Framework\TestCase')) {
-   class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
+if (phpversion() > '5.3.0') {
+	if (class_exists('\PHPUnit\Framework\TestCase')) {
+	   class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
+	}
 }
-
 
 /**
  *

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,7 +5,7 @@ require_once dirname(__FILE__) . '/../idiorm.php';
 /**
  * Ugly workaround for modern phpunit to support old php versions
  */
-if (class_exists('\PHPUnit\Framework\TestCase') && version_compare(PHP_VERSION, '5.3') >= 0) {
+if (class_exists('\PHPUnit\Framework\TestCase') && version_compare(PHP_VERSION, '5.2') >= 0) {
 	class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
 	{
 	}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,7 +5,7 @@ require_once dirname(__FILE__) . '/../idiorm.php';
 /**
  * Ugly workaround for modern phpunit to support old php versions
  */
-if (class_exists('\PHPUnit\Framework\TestCase') && version_compare(PHP_VERSION, '5.2') >= 0) {
+if (class_exists('\PHPUnit\Framework\TestCase') && version_compare(PHP_VERSION, '5.4') > -1) {
 	class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
 	{
 	}


### PR DESCRIPTION
Refactor join() to implode() as of deprecated warning in PHP 7.4... therefore some strict unit testing suites (like mine) that turn warnings into errors are going to fail.

While fixing PHPUnit to support 5.x up to 7.4 it turns out that we cannot support both. PHP 7.4 needs PHPUnit 8 at least - that release enforces return types for `setUp` and `tearDown` that will cause syntax error in 5.x... 

**So now this is an dead end accept we create a testing suite for 5.x and 7.4+**

+ I had to put lot of work into fixing Travis CI - PHP 7.4 is not passing at the moment!
+ HHVM has been removed because composer no longer supports it:
https://github.com/composer/composer/issues/8127
+ Added hack to bootstrap to support old and new PHPUnit namespace

```php
if (class_exists('\PHPUnit\Framework\TestCase')) {
	class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
	{
	}
}
```

Supported PHPUnit versions: https://phpunit.de/supported-versions.html