### PR TITLE
Added type casting of the returned results from a query.

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -128,6 +128,13 @@
         const LIMIT_STYLE_TOP_N = "top";
         const LIMIT_STYLE_LIMIT = "limit";
 
+        // Internal Types
+        const TYPE_BOOL = 'boolean';
+        const TYPE_INT = 'integer';
+        const TYPE_FLOAT = 'float';
+        const TYPE_STRING = 'string';
+        const TYPE_TIME = 'time';
+
         // ------------------------ //
         // --- CLASS PROPERTIES --- //
         // ------------------------ //
@@ -148,6 +155,7 @@
             'caching' => false,
             'caching_auto_clear' => false,
             'return_result_sets' => false,
+            'column_casts' => array(),
         );
 
         // Map of configuration settings
@@ -1909,8 +1917,29 @@
             self::_execute($query, $this->_values, $this->_connection_name);
             $statement = self::get_last_statement();
 
+			$type_casting = self::$_config[$this->_connection_name]['column_casts'];
             $rows = array();
             while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+                /**
+                 * Convert sql string to php type
+                 */
+                if (count($type_casting) > 0) {
+                    foreach($type_casting AS $col => $type) {
+                        if (isset($row[$col])) {
+                            switch($type){
+                                case self::TYPE_BOOL:
+                                case self::TYPE_INT:
+                                case self::TYPE_FLOAT:
+                                case self::TYPE_STRING:
+                                    settype($row[$col], $type);
+                                    break;
+                                case self::TYPE_TIME:
+                                    $row[$col] = new DateTime($row[$col]);
+                            }
+                        }
+                    }
+                }
+
                 $rows[] = $row;
             }
 

--- a/idiorm.php
+++ b/idiorm.php
@@ -2,9 +2,10 @@
 
     /**
      *
-     * Idiorm
+     * Idiorm Modified
      *
-     * http://github.com/j4mie/idiorm/
+     * original: http://github.com/j4mie/idiorm/
+     * modified: https://github.com/psycho-neon/idiorm/
      *
      * A single-class super-simple database abstraction layer for PHP.
      * Provides (nearly) zero-configuration object-relational mapping
@@ -276,7 +277,7 @@
                 }
             } else {
                 if (is_null($value)) {
-                    // Shortcut: If only one string argument is passed, 
+                    // Shortcut: If only one string argument is passed,
                     // assume it's a connection string
                     $value = $key;
                     $key = 'connection_string';
@@ -304,7 +305,7 @@
         public static function reset_config() {
             self::$_config = array();
         }
-        
+
         /**
          * Despite its slightly odd name, this is actually the factory
          * method used to acquire instances of the class. It is named
@@ -393,7 +394,7 @@
 
         /**
          * Detect and initialise the limit clause style ("SELECT TOP 5" /
-         * "... LIMIT 5"). If this has been specified manually using 
+         * "... LIMIT 5"). If this has been specified manually using
          * ORM::configure('limit_clause_style', 'top'), this will do nothing.
          * @param string $connection_name Which connection to use
          */
@@ -571,13 +572,13 @@
 
             self::$_last_query = $bound_query;
             self::$_query_log[$connection_name][] = $bound_query;
-            
-            
+
+
             if(is_callable(self::$_config[$connection_name]['logger'])){
                 $logger = self::$_config[$connection_name]['logger'];
                 $logger($bound_query, $query_time);
             }
-            
+
             return true;
         }
 
@@ -744,7 +745,7 @@
          * @return array
          */
         public function find_array() {
-            return $this->_run(); 
+            return $this->_run();
         }
 
         /**
@@ -916,14 +917,14 @@
          * Add columns to the list of columns returned by the SELECT
          * query. This defaults to '*'. Many columns can be supplied
          * as either an array or as a list of parameters to the method.
-         * 
+         *
          * Note that the alias must not be numeric - if you want a
          * numeric alias then prepend it with some alpha chars. eg. a1
-         * 
+         *
          * @example select_many(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5');
          * @example select_many('column', 'column2', 'column3');
          * @example select_many(array('column', 'column2', 'column3'), 'column4', 'column5');
-         * 
+         *
          * @return \ORM
          */
         public function select_many() {
@@ -942,16 +943,16 @@
 
         /**
          * Add an unquoted expression to the list of columns returned
-         * by the SELECT query. Many columns can be supplied as either 
+         * by the SELECT query. Many columns can be supplied as either
          * an array or as a list of parameters to the method.
-         * 
+         *
          * Note that the alias must not be numeric - if you want a
          * numeric alias then prepend it with some alpha chars. eg. a1
-         * 
+         *
          * @example select_many_expr(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5')
          * @example select_many_expr('column', 'column2', 'column3')
          * @example select_many_expr(array('column', 'column2', 'column3'), 'column4', 'column5')
-         * 
+         *
          * @return \ORM
          */
         public function select_many_expr() {
@@ -971,11 +972,11 @@
         /**
          * Take a column specification for the select many methods and convert it
          * into a normalised array of columns and aliases.
-         * 
+         *
          * It is designed to turn the following styles into a normalised array:
-         * 
+         *
          * array(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5'))
-         * 
+         *
          * @param array $columns
          * @return array
          */
@@ -1137,7 +1138,7 @@
             foreach ($data as $key => $val) {
                 $column = $result->_quote_identifier($key);
                 $placeholders = $result->_create_placeholders($val);
-                $result = $result->_add_having("{$column} {$separator} ({$placeholders})", $val);    
+                $result = $result->_add_having("{$column} {$separator} ({$placeholders})", $val);
             }
             return $result;
         }
@@ -1182,7 +1183,7 @@
             foreach ($data as $key => $val) {
                 $column = $result->_quote_identifier($key);
                 $placeholders = $result->_create_placeholders($val);
-                $result = $result->_add_where("{$column} {$separator} ({$placeholders})", $val);    
+                $result = $result->_add_where("{$column} {$separator} ({$placeholders})", $val);
             }
             return $result;
         }
@@ -1241,7 +1242,7 @@
                 $result = $result->_add_condition($type, "{$key} {$separator} ?", $val);
             }
             return $result;
-        } 
+        }
 
         /**
          * Return a string containing the given number of question marks,
@@ -1261,7 +1262,7 @@
                 return implode(', ', $db_fields);
             }
         }
-        
+
         /**
          * Helper method that filters a column/value array returning only those
          * columns that belong to a compound primary key.
@@ -1338,7 +1339,7 @@
          * it can be overriden for any or every column using the second parameter.
          *
          * Each condition will be ORed together when added to the final query.
-         */        
+         */
         public function where_any_is($values, $operator='=') {
             $data = array();
             $query = array("((");
@@ -1514,7 +1515,7 @@
         }
 
         /**
-         * Add an unquoted expression to the list of columns to GROUP BY 
+         * Add an unquoted expression to the list of columns to GROUP BY
          */
         public function group_by_expr($expr) {
             $this->_group_by[] = $expr;
@@ -1917,7 +1918,7 @@
             self::_execute($query, $this->_values, $this->_connection_name);
             $statement = self::get_last_statement();
 
-			$type_casting = self::$_config[$this->_connection_name]['column_casts'];
+			$type_casting = self::$_config[$this->_connection_name]['column_casts'][$this->_table_name] ?? array();
             $rows = array();
             while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
                 /**
@@ -2044,7 +2045,7 @@
          * To set multiple properties at once, pass an associative array
          * as the first parameter and leave out the second parameter.
          * Flags the properties as 'dirty' so they will be saved to the
-         * database when save() is called. 
+         * database when save() is called.
          * @param string|array $key
          * @param string|null $value
          */
@@ -2280,12 +2281,12 @@
 
         /**
          * Magic method to capture calls to undefined class methods.
-         * In this case we are attempting to convert camel case formatted 
+         * In this case we are attempting to convert camel case formatted
          * methods into underscore formatted methods.
          *
-         * This allows us to call ORM methods using camel case and remain 
+         * This allows us to call ORM methods using camel case and remain
          * backwards compatible.
-         * 
+         *
          * @param  string   $name
          * @param  array    $arguments
          * @return ORM
@@ -2302,13 +2303,13 @@
         }
 
         /**
-         * Magic method to capture calls to undefined static class methods. 
-         * In this case we are attempting to convert camel case formatted 
+         * Magic method to capture calls to undefined static class methods.
+         * In this case we are attempting to convert camel case formatted
          * methods into underscore formatted methods.
          *
-         * This allows us to call ORM methods using camel case and remain 
+         * This allows us to call ORM methods using camel case and remain
          * backwards compatible.
-         * 
+         *
          * @param  string   $name
          * @param  array    $arguments
          * @return ORM
@@ -2469,7 +2470,7 @@
         public function as_array() {
             return $this->get_results();
         }
-        
+
         /**
          * Get the number of records in the result set
          * @return int
@@ -2504,7 +2505,7 @@
         public function offsetGet($offset) {
             return $this->_results[$offset];
         }
-        
+
         /**
          * ArrayAccess
          * @param int|string $offset


### PR DESCRIPTION
The idea came from Laravel's Eloquent Model type casting. 
I am happy with using this module since it has very small footprint than the bloated one. Hopefully this gets accepted.

Usage:

```
ORM::configure('column_casts', [
  'id' => 'integer',
  'updated_at' => 'time',
  'some_float' => 'float',
  'some_boolean' => 'boolean'
]);
```

Columns with a name/alias of `id, updated_at, some_float, some_boolean` from the returned result will be converted on their respective types.