### PR TITLE
PHP Warning fix

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -2101,8 +2101,10 @@
                         // it may return several columns if a compound primary
                         // key is used
                         $row = self::get_last_statement()->fetch(PDO::FETCH_ASSOC);
-                        foreach($row as $key => $value) {
-                            $this->_data[$key] = $value;
+                        if(is_array($row)) {
+                            foreach($row as $key => $value) {
+                                $this->_data[$key] = $value;
+                            }
                         }
                     } else {
                         $column = $this->_get_id_column_name();


### PR DESCRIPTION
```log
Invalid argument supplied for foreach() in /XXX/vendor/j4mie/idiorm/idiorm.php : 2104
foreach() argument must be of type array\|object, bool given in /XXX/vendor/j4mie/idiorm/idiorm.php : 2104
```
When a table has a insert before trigger then $row is equal to false and produces this warnings, thats a postgresql problem so i think that catch is all we can do here.