### PR TITLE
Query logging now properly logs NULL values without deprecation notices

### DIFF
--- a/idiorm.php
+++ b/idiorm.php
@@ -536,7 +536,10 @@
                 $bound_query = $query;
             } else {
                 // Escape the parameters
-                $parameters = array_map(array(self::get_db($connection_name), 'quote'), $parameters);
+                $db = self::get_db($connection_name);
+                foreach ($parameters as $key => $value) {
+                    $parameters[$key] = $value === null ? 'NULL' : $db->quote($value);
+                }
 
                 if (array_values($parameters) === $parameters) {
                     // ? placeholders

--- a/test/QueryBuilderTest.php
+++ b/test/QueryBuilderTest.php
@@ -692,5 +692,13 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
         $expected = "SELECT * FROM `sqlite_master` LIMIT 1";
         $this->assertEquals($expected, ORM::get_last_query());
     }
+
+    public function testIssue374LoggingWithNullValue() {
+        $widget = ORM::for_table('widget')->find_one(1);
+        $widget->age = NULL;
+        $widget->save();
+        $expected = "UPDATE `widget` SET `age` = NULL WHERE `id` = '1'";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
 }
 

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -33,7 +33,7 @@ class MockPDOStatement extends PDOStatement {
            }
            $count = count($m);
            for ($i = 0; $i < $count; $i++) {
-               if (!isset($params[$i])) {
+               if (!array_key_exists($i, $params)) {
                    ob_start();
                    var_dump($m, $params);
                    $output = ob_get_clean();


### PR DESCRIPTION
This PR fixes issue #374 that describes 2 problems with logging and using queries with NULL values:
 1. the query logging is creating PHP deprecation notices on PHP 8.1+ (`Deprecated: PDO::quote(): Passing null to parameter #1 ($string) of type string is deprecated in [....]j4mie\idiorm\idiorm.php on line 539`)
 2. the NULL value is represented in log exactly same as empty string

This PR is similiar to unmerged PR #375 that also changes logging handling with booleans. Due to discussion https://github.com/j4mie/idiorm/pull/375#issuecomment-2019788467 with raised concerns with MS SQL compatibility (even though this is affecting only logging output, not the query sent to the DB server) i have created with this PR with more minimal changes (+added phpunit test).

Changed files:
 - test/QueryBuilderTest.php - added test
 - test/bootstrap.php - one liner fix to handle NULL parameters in tests
 - idiorm.php - updated `_log_query` function